### PR TITLE
address hanging process on SASS syntax error

### DIFF
--- a/.tape.js
+++ b/.tape.js
@@ -42,6 +42,16 @@ module.exports = {
 				require('.')
 			),
 			processOptions: processOptions
+		},
+		'sass-error': {
+			message: 'exits cleanly on SASS syntax error',
+			error: {
+				reason: /^Missed semicolon/
+			},
+			plugin: () => require('postcss')(
+				require('.')
+			),
+			processOptions: processOptions
 		}
 	}
 };

--- a/test/sass-error.css
+++ b/test/sass-error.css
@@ -1,0 +1,3 @@
+$var1: hi
+$var2: there;
+


### PR DESCRIPTION
Problem: A syntactic error in a SASS file may lead to a hanging process due to a known issue in node-sass ([https://github.com/sass/node-sass/issues/1048](https://github.com/sass/node-sass/issues/1048)).

Solution: Invoke sass.renderSync instead of sass.render.

Discussion: 

1. The issue occurs, for instance, when running the plugin within grunt-postcss (e.g. when compiling test/sass-error.css in this PR). Any SASS syntax error appears to lead to a hanging process. 
1. The PR adds a test case to verify a clean exit on encountering a SASS syntax error (sass-error.css). As part of the tape test suite, this test succeeds with the original postcss-sass code. I am not sure how to explain this fact; the internal logic of a tape test in npm may account for it.
1. The suggested solution in [https://github.com/sass/node-sass/issues/1048](https://github.com/sass/node-sass/issues/1048) does not appear to address the issue when running in grunt.
1. My proposal is to invoke sass.renderSync and catch any error it may emit. 
1. As a side-effect of invoking sass.renderSync instead of sass.render, the existing test of import functionality (test/imports.css) now triggers the (appropriate) deprecation warning "Including .css files with @import is non-standard behaviour which will be removed in future versions of LibSass" (see, for instance, [https://github.com/sass/node-sass/issues/2362](https://github.com/sass/node-sass/issues/2362)). (This message could be suppressed by adding the .css extension to @import statements in test/import.css, but then  the test imports:postcss would fail.)

Jonathan, thank you for your work on this plugin!

Best wishes,

M.