### PR TITLE
Allow using a custom sass importer option

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ export default postcss.plugin('postcss-sass', opts => (root, result) => {
 	}
 	
 	// sass importer
-	const sassImporter = opts.importer || defaultSassImporter
+	const sassImporter = (opts && opts.importer) || defaultSassImporter
 
 	return new Promise(
 		// promise sass results

--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ export default postcss.plugin('postcss-sass', opts => (root, result) => {
 	}
 	
 	// sass importer
-	const sassImporter = (opts && opts.importer) || defaultSassImporter
+	const sassImporter = opts && opts.importer || defaultSassImporter
 
 	return new Promise(
 		// promise sass results

--- a/index.js
+++ b/index.js
@@ -18,9 +18,9 @@ export default postcss.plugin('postcss-sass', opts => (root, result) => {
 
 	// sass resolve cache
 	const cache = {};
-	
-	// sass importer
-	const sassImporter = opts.importer || (id, parentId, done) => {
+
+	// replication of the default sass file importer
+	const defaultSassImporter = (id, parentId, done) => {
 		// resolve the absolute parent
 		const parent = pathResolve(parentId);
 
@@ -44,6 +44,9 @@ export default postcss.plugin('postcss-sass', opts => (root, result) => {
 			}
 		);
 	}
+	
+	// sass importer
+	const sassImporter = opts.importer || defaultSassImporter
 
 	return new Promise(
 		// promise sass results

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ export default postcss.plugin('postcss-sass', opts => (root, result) => {
 			}
 		);
 	}
-	
+
 	// sass importer
 	const sassImporter = opts && opts.importer || defaultSassImporter
 
@@ -69,8 +69,11 @@ export default postcss.plugin('postcss-sass', opts => (root, result) => {
 						done(importerResult)
 					}
 
+					// strip the #sass suffix we added
+					const prev = parentId.replace(/#sass$/, '')
+
 					// call the sass importer and catch its output
-					sassImporter.call(this, id, parentId, doneWrap)
+					sassImporter.call(this, id, prev, doneWrap)
 				}
 			}),
 			(sassError, sassResult) => sassError ? reject(sassError) : resolve(sassResult)


### PR DESCRIPTION
The current implementation of the `importer` is actually a re-implementation of the default sass file importer, that catches the resolved `file` path for the watcher. This change allows replacing the default `importer` implementation, while still pushing the `dependency` to the watch task.