### PR TITLE
Allow configuring the sass engine

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,12 +16,15 @@ export default postcss.plugin('postcss-sass', opts => (root, result) => {
 	// include paths
 	const includePaths = [].concat(opts && opts.includePaths || []);
 
+	// sass engine to use
+	const sassEngine = opts && opts.sass || sass
+
 	// sass resolve cache
 	const cache = {};
 
 	return new Promise(
 		// promise sass results
-		(resolve, reject) => sass.render(
+		(resolve, reject) => sassEngine.render(
 			// pass options directly into node-sass
 			Object.assign({}, opts, requiredSassConfig, {
 				file: `${postConfig.from}#sass`,


### PR DESCRIPTION
According to [this article](https://davidgracieweb.co.uk/node-sass-vs-grunt-sass-vs-dart-sass-vs-ruby-sass/) `node-sass` may be behind in terms of features but is still faster by a factor of around 2.