### PR TITLE
docs(README): Fix example usage of postcss-scss

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ const postcssSass = require('@csstools/postcss-sass');
 postcss([
   postcssSass(/* pluginOptions */)
 ]).process(YOUR_CSS, {
-  syntax: 'postcss-scss'
+  syntax: require('postcss-scss')
 });
 ```
 


### PR DESCRIPTION
Thanks for maintaining this! Compiling SCSS entirely via a PostCSS pipeline has been great.

The README documents using the `postcss-scss` parser, but uses a configuration style that I think only works in JSON configurations (certainly doesn’t work with the programmatic JS API shown in the example). To work correctly the parser needs to be required. This PR fixes the example to show this.