### PR TITLE
fix: Update import from sass

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 // tooling
 import mergeSourceMaps from './merge-source-maps';
 import sassResolve from '@csstools/sass-import-resolve';
-import sass from 'sass';
+import * as sass from 'sass';
 import { dirname, resolve as pathResolve } from 'path';
 
 const requiredPostConfig = {


### PR DESCRIPTION
Sass has declared that `import sass from 'sass'` is deprecated so now index.js imports as sass indicates.

The following image is from a project i'm on and i fixed this issue modifiing the bundled file.

![image](https://github.com/csstools/postcss-sass/assets/14881608/05354126-f5cb-4c5f-b1bc-943709b6d71a)

